### PR TITLE
Feature/issue#8/command end point

### DIFF
--- a/ADSDeploy/config.py
+++ b/ADSDeploy/config.py
@@ -9,7 +9,7 @@ SQLALCHEMY_ECHO = False
 # Configuration of the pipeline; if you start 'vagrant up rabbitmq' 
 # container, the port is localhost:6672 - but for production, you 
 # want to point to the ADSImport pipeline 
-RABBITMQ_URL = 'amqp://guest:guest@127.0.0.1:6672/?' \
+RABBITMQ_URL = 'amqp://guest:guest@172.17.0.1:6672/?' \
                'socket_timeout=10&backpressure_detection=t'
                
 

--- a/ADSDeploy/tests/test_functional/test_webapp.py
+++ b/ADSDeploy/tests/test_functional/test_webapp.py
@@ -21,7 +21,6 @@ class TestWebApp(unittest.TestCase):
     """
 
     def setUp(self):
-
         with MiniRabbit(RABBITMQ_URL) as w:
             w.make_queue('test')
 
@@ -34,19 +33,18 @@ class TestWebApp(unittest.TestCase):
         Test that the end points publishes messages to the correct queue
         """
 
-        url = 'http://{}/rabbit'.format(WEBAPP_URL)
+        url = 'http://{}/command'.format(WEBAPP_URL)
 
         payload = {
-            'queue': 'deploy',
-            'commit': '23d3f',
-            'service': 'adsws',
-            'route': 'test',
-            'exchange': 'test'
+            'application': 'staging',
+            'environment': 'adsws',
+            'commit': 's23rfef3',
         }
 
         r = requests.post(url, data=json.dumps(payload))
 
         self.assertEqual(r.status_code, 200)
+
         self.assertEqual(r.json()['msg'], 'success')
 
         with MiniRabbit(RABBITMQ_URL) as w:
@@ -59,9 +57,6 @@ class TestWebApp(unittest.TestCase):
             msg='Expected 1 message, but found: {}'.format(messages)
         )
 
-        # We do not expect exchange or route in the payload
-        payload.pop('exchange')
-        payload.pop('route')
         self.assertEqual(
             packet,
             payload,

--- a/ADSDeploy/tests/test_unit/test_webservices.py
+++ b/ADSDeploy/tests/test_unit/test_webservices.py
@@ -23,6 +23,8 @@ class TestEndpoints(TestCase):
         app_ = app.create_app()
         app_.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
         app_.config['DEPLOY_LOGGING'] = {}
+        app_.config['EXCHANGE'] = 'unit-test-exchange'
+        app_.config['ROUTE'] = 'unit-test-route'
         return app_
 
     def test_githublistener_endpoint(self):
@@ -68,7 +70,7 @@ class TestEndpoints(TestCase):
         }
 
         mocked_rabbit.assert_has_calls(
-            [mock.call(expected_packet, exchange='ADSDeploy', route='ads.deploy.before_deploy')]
+            [mock.call(expected_packet, exchange='unit-test-exchange', route='unit-test-route')]
         )
 
     @mock.patch('ADSDeploy.webapp.views.GithubListener')
@@ -84,8 +86,7 @@ class TestEndpoints(TestCase):
         payload = {
             'application': 'staging',
             'commit': '23d3f',
-            'tag': 'v1.0.0',
-            'service': 'adsws',
+            'environment': 'adsws',
         }
 
         r = self.client.post(url, data=json.dumps(payload))
@@ -94,7 +95,7 @@ class TestEndpoints(TestCase):
         self.assertEqual(r.json['msg'], 'success')
 
         mocked_gh.push_rabbitmq.assert_has_calls(
-            [mock.call(payload, exchange='ADSDeploy', route='ads.deploy.before_deploy')]
+            [mock.call(payload, exchange='unit-test-exchange', route='unit-test-route')]
         )
 
     @mock.patch('ADSDeploy.webapp.views.GithubListener')
@@ -109,8 +110,7 @@ class TestEndpoints(TestCase):
 
         payload = {
             'application': 'staging',
-            'service': 'adsws',
-            'commit': 'latest-commit'
+            'environment': 'adsws',
         }
 
         r = self.client.post(url, data=json.dumps(payload))

--- a/ADSDeploy/tests/test_unit/test_workers.py
+++ b/ADSDeploy/tests/test_unit/test_workers.py
@@ -285,12 +285,16 @@ class TestWorkers(test_base.TestUnit):
             Base.metadata.create_all()
         return app
 
+    @mock.patch('ADSDeploy.pipeline.deploy.os.path.exists')
     @mock.patch('ADSDeploy.pipeline.deploy.BeforeDeploy.publish')
     @mock.patch('ADSDeploy.osutils.Executioner.cmd', 
                 return_value=Mock(**dict(retcode=0, 
                                          out='Ready adsws-sandbox.elasticbeanstalk.com adsws:v1.0.0:v1.0.2-17-g1b31375 Green adsws-sandbox')))
-    def test_deploy_before_deploy(self, PatchedBeforeDeploy, exect):
+    def test_deploy_before_deploy(self, PatchedBeforeDeploy, exect, exists):
         """Checks the worker has access to the AWS"""
+        # BeforeDeploy requires EB_DEPLOY path to exist
+        exists.return_value = True
+
         worker = BeforeDeploy()
         worker.process_payload({'application': 'sandbox', 'environment': 'adsws'})
         worker.publish.assert_called_with({'environment': 'adsws', 'application': 'sandbox', 'msg': 'OK to deploy'})

--- a/ADSDeploy/webapp/app.py
+++ b/ADSDeploy/webapp/app.py
@@ -7,7 +7,7 @@ import os
 
 from flask import Flask
 from flask.ext.restful import Api
-from views import GithubListener, RabbitMQListener
+from views import GithubListener, CommandView
 from .models import db
 
 
@@ -31,7 +31,7 @@ def create_app(name='ADSDeploy'):
     # Register extensions
     api = Api(app)
     api.add_resource(GithubListener, '/webhooks', methods=['POST'])
-    api.add_resource(RabbitMQListener, '/rabbit', methods=['POST'])
+    api.add_resource(CommandView, '/command', methods=['POST'])
     db.init_app(app)
 
     return app

--- a/ADSDeploy/webapp/config.py
+++ b/ADSDeploy/webapp/config.py
@@ -1,3 +1,13 @@
+import os
+
+LOG_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '../../')
+)
+LOG_PATH = '{home}/logs'.format(home=LOG_PATH)
+
+if not os.path.isdir(LOG_PATH):
+    os.mkdir(LOG_PATH)
+
 GITHUB_SIGNATURE_HEADER = 'X-Hub-Signature'
 GITHUB_SECRET = 'redacted'
 GITHUB_COMMIT_API = 'https://api.github.com/repos/adsabs/{repo}/git/commits/{hash}'
@@ -23,10 +33,16 @@ DEPLOY_LOGGING = {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler'
         },
+        'file': {
+            'filename': '{}/webapp.log'.format(LOG_PATH),
+            'formatter': 'default',
+            'class': 'logging.handlers.TimedRotatingFileHandler',
+            'level': 'DEBUG'
+        }
     },
     'loggers': {
         '': {
-            'handlers': ['console'],
+            'handlers': ['console', 'file'],
             'level': 'DEBUG',
             'propagate': True,
         },

--- a/ADSDeploy/webapp/views.py
+++ b/ADSDeploy/webapp/views.py
@@ -7,7 +7,7 @@ import hmac
 import json
 
 import pika
-from ADSDeploy.config import RABBITMQ_URL, EXCHANGE, FIRST_ROUTE
+from ADSDeploy.config import RABBITMQ_URL
 from flask import current_app, request, abort
 from flask.ext.restful import Resource
 


### PR DESCRIPTION
Not too many changes. Modified /rabbitmq to /command, and now it
has the relevant keywords included, and also the tests updated.

Fixed some tests after merging with upstream/master.