### PR TITLE
Feature/updating db forwarding

### DIFF
--- a/ADSDeploy/config.py
+++ b/ADSDeploy/config.py
@@ -9,7 +9,7 @@ SQLALCHEMY_ECHO = False
 # Configuration of the pipeline; if you start 'vagrant up rabbitmq' 
 # container, the port is localhost:6672 - but for production, you 
 # want to point to the ADSImport pipeline 
-RABBITMQ_URL = 'amqp://guest:guest@127.0.0.1:6672/?' \
+RABBITMQ_URL = 'amqp://guest:guest@172.17.0.1:6672/?' \
                'socket_timeout=10&backpressure_detection=t'
                
 

--- a/ADSDeploy/config.py
+++ b/ADSDeploy/config.py
@@ -9,7 +9,7 @@ SQLALCHEMY_ECHO = False
 # Configuration of the pipeline; if you start 'vagrant up rabbitmq' 
 # container, the port is localhost:6672 - but for production, you 
 # want to point to the ADSImport pipeline 
-RABBITMQ_URL = 'amqp://guest:guest@172.17.0.1:6672/?' \
+RABBITMQ_URL = 'amqp://guest:guest@127.0.0.1:6672/?' \
                'socket_timeout=10&backpressure_detection=t'
                
 

--- a/ADSDeploy/config.py
+++ b/ADSDeploy/config.py
@@ -31,6 +31,10 @@ WORKERS = {
         'concurrency': 1,
         'subscribe': 'ads.deploy.before_deploy',
         'publish': 'ads.deploy.deploy',
+        'forwarding': {
+            'exchange': EXCHANGE,
+            'publish': 'ads.deploy.status'
+        },
         'error': 'ads.deploy.error',
         'durable': True
     },
@@ -38,6 +42,10 @@ WORKERS = {
         'concurrency': 1,
         'subscribe': 'ads.deploy.deploy',
         'publish': 'ads.deploy.test',
+        'forwarding': {
+            'exchange': EXCHANGE,
+            'publish': 'ads.deploy.status'
+        },
         'error': 'ads.deploy.error',
         'durable': True
     },
@@ -45,6 +53,10 @@ WORKERS = {
         'concurrency': 1,
         'subscribe': 'ads.deploy.test',
         'publish': 'ads.deploy.after_deploy',
+        'forwarding': {
+            'exchange': EXCHANGE,
+            'publish': 'ads.deploy.status'
+        },
         'error': 'ads.deploy.error',
         'durable': True
     },

--- a/ADSDeploy/models.py
+++ b/ADSDeploy/models.py
@@ -45,8 +45,9 @@ class Deployment(Base):
         default=datetime.utcnow,
         onupdate=datetime.utcnow
     )
-    deployed = Column(Boolean, default=False)
-    tested = Column(Boolean, default=False)
+    deployed = Column(Boolean, nullable=True)
+    tested = Column(Boolean, nullable=True)
+    msg = Column(String)
 
     def toJSON(self):
         """
@@ -62,6 +63,7 @@ class Deployment(Base):
             'date_last_modified': self.date_last_modified.isoformat(),
             'deployed': self.deployed,
             'tested': self.tested,
+            'msg': self.msg
         }
 
     def __repr__(self):
@@ -77,7 +79,8 @@ class Deployment(Base):
             '\tdate_created: {}'.format(self.date_created),
             '\tdate_last_modified: {}'.format(self.date_last_modified),
             '\tdeployed: {}'.format(self.deployed),
-            '\ttested: {}'.format(self.tested)
+            '\ttested: {}'.format(self.tested),
+            '\tmsg: {}'.format(self.msg)
         ]
 
         return '<Deployment (\n{}\n)>'.format(', \n'.join(_repr))

--- a/ADSDeploy/pipeline/deploy.py
+++ b/ADSDeploy/pipeline/deploy.py
@@ -55,13 +55,19 @@ class BeforeDeploy(RabbitMQWorker):
         if is_timedout(payload, timestamp_key='init_timestamp'):
             payload['err'] = 'timeout'
             payload['msg'] = 'BeforeDeploy: waiting too long for the environment to come up'
-            return self.publish_to_error_queue(payload)
+            payload['deployed'] = False
+
+            self.forward(payload)
+
+            return self.publish_to_error_queue(payload,
+                                               header_frame=header_frame)
         
         x = create_executioner(payload)
         
         # checks we can access the AWS and that the environment in question
         # is not busy
         r = x.cmd("./find-env-by-attr url {0}".format(payload['environment']))
+        self.logger.info(r.retcode)
         assert r.retcode == 0
         
         for l in r.out.splitlines():
@@ -77,6 +83,8 @@ class BeforeDeploy(RabbitMQWorker):
         
         # all is OK, we can proceed
         payload['msg'] = 'OK to deploy'
+
+        self.forward(payload)
         self.publish(payload)
 
         
@@ -95,21 +103,23 @@ class Deploy(RabbitMQWorker):
         """Runs the actual deployment. It calls the eb-deploy safe-deploy.sh."""
         
         x = create_executioner(payload)
-        self.publish({'msg': '{0}-{1} deployment starts'.format(payload['environment'], payload['application'])}, 
-                      topic='ads.deploy.status')
-        
+        payload['msg'] = '{0}-{1} deployment starts'.format(payload['environment'], payload['application'])
+        self.publish(payload, topic='ads.deploy.status')
+
         # this will run for a few minutes!
         r = x.cmd('./safe-deploy.sh {0} > /tmp/deploy.{0}.{1}'.format(payload['environment'], payload['application']))
         if r.retcode == 0:
+            payload['deployed'] = True
             payload['msg'] = 'deployed'
-            self.publish(payload) 
-            self.publish({'msg': '{0}-{1} deployment finished'.format(payload['environment'], payload['application'])}, 
-                      topic='ads.deploy.status')
+            self.publish(payload)
+            self.publish(payload, topic='ads.deploy.status')
         else:
             payload['err'] = 'deployment failed'
-            payload['msg'] = 'command: {0}, reason: {1}, stdout: {2}'.format(r.command, r.err, r.out)
+            payload['deployed'] = False
+            payload['msg'] = 'deployment failed; command: {0}, reason: {1}, ' \
+                             'stdout: {2}'.format(r.command, r.err, r.out)
+            self.publish(payload, topic='ads.deploy.status')
             self.publish_to_error_queue(payload)
-
 
 
 class AfterDeploy(RabbitMQWorker):

--- a/ADSDeploy/pipeline/generic.py
+++ b/ADSDeploy/pipeline/generic.py
@@ -98,7 +98,7 @@ class RabbitMQWorker(object):
         :param exchange: name of the exchange that contains the error queue
         :param routing_key: routing key for the error queue
         :param kwargs: extra keywords that may be needed
-        :return: no return
+        :return: no return1
         """
         if not exchange:
             exchange = self.params.get('exchange', 'ads-deploy')

--- a/ADSDeploy/pipeline/integration_tester.py
+++ b/ADSDeploy/pipeline/integration_tester.py
@@ -17,7 +17,7 @@ from collections import OrderedDict
 ADS_REX_URL = 'https://github.com/adsabs/adsrex.git'
 ADS_REX_BRANCH = 'develop'
 ADS_REX_TMP = '/tmp/adsrex'
-ADS_REX_PASS_KEYWORD = 'test passed'
+ADS_REX_PASS_KEYWORD = 'tested'
 
 ADS_REX_LOCAL_CONFIG = OrderedDict(
     API_BASE='https://devapi.adsabs.harvard.edu',
@@ -86,7 +86,11 @@ class IntegrationTestWorker(RabbitMQWorker):
             # Step 2: run the tests via subprocess
             script = ['py.test']
             with ChangeDirectory(ADS_REX_TMP):
-                p = subprocess.Popen(script, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
+                p = subprocess.Popen(
+                    script,
+                    stdout=subprocess.PIPE,
+                    stdin=subprocess.PIPE
+                )
 
             out, err = p.communicate()
 
@@ -117,7 +121,7 @@ class IntegrationTestWorker(RabbitMQWorker):
 
         # do something with the payload
         msg = dict(msg)
-        result = IntegrationTestWorker.run_test(msg=msg)
+        result = self.run_test(msg=msg)
 
         if not msg.get('application', None):
             self.logger.error('Application keyword was not specified.')
@@ -125,4 +129,6 @@ class IntegrationTestWorker(RabbitMQWorker):
 
         # publish the results into the queue
         self.logger.info('Publishing to queue: {}'.format(self.publish_topic))
+
         self.publish(result)
+        self.forward(result)

--- a/ADSDeploy/pipeline/workers.py
+++ b/ADSDeploy/pipeline/workers.py
@@ -4,3 +4,4 @@ Place holder for all workers
 """
 from .integration_tester import IntegrationTestWorker
 from .db_writer import DatabaseWriterWorker
+from .deploy import BeforeDeploy

--- a/ADSDeploy/pipeline/workers.py
+++ b/ADSDeploy/pipeline/workers.py
@@ -4,4 +4,4 @@ Place holder for all workers
 """
 from .integration_tester import IntegrationTestWorker
 from .db_writer import DatabaseWriterWorker
-from .deploy import BeforeDeploy
+from .deploy import BeforeDeploy, Deploy

--- a/ADSDeploy/tests/test_functional/test_before_deploy.py
+++ b/ADSDeploy/tests/test_functional/test_before_deploy.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+"""
+Functional tests of the RabbitMQ Workers
+"""
+
+import mock
+import json
+import unittest
+import ADSDeploy.app as app
+
+from ADSDeploy.pipeline.workers import BeforeDeploy, DatabaseWriterWorker
+from ADSDeploy.webapp.views import MiniRabbit
+from ADSDeploy.models import Base, Deployment
+
+RABBITMQ_URL = 'amqp://guest:guest@172.17.0.1:6672/?' \
+               'socket_timeout=10&backpressure_detection=t'
+
+
+class TestBeforeDeployWorker(unittest.TestCase):
+    """
+    Tests the functionality of the Before Deploy worker
+    """
+    def setUp(self):
+        # Create queue
+        with MiniRabbit(RABBITMQ_URL) as w:
+            w.make_queue('in', exchange='test')
+            w.make_queue('out', exchange='test')
+            w.make_queue('database', exchange='test')
+
+        # Create database
+        app.init_app({
+            'SQLALCHEMY_URL': 'sqlite://',
+            'SQLALCHEMY_ECHO': False,
+        })
+        Base.metadata.bind = app.session.get_bind()
+        Base.metadata.create_all()
+        self.app = app
+
+    def tearDown(self):
+        # Destroy queue
+        with MiniRabbit(RABBITMQ_URL) as w:
+            w.delete_queue('in', exchange='test')
+            w.delete_queue('out', exchange='test')
+            w.delete_queue('database', exchange='test')
+
+        # Destroy database
+        Base.metadata.drop_all()
+        self.app.close_app()
+
+    @mock.patch('ADSDeploy.pipeline.deploy.is_timedout')
+    def test_before_deploy_fails(self, mock_is_timedout):
+        """
+        General work flow of the integration worker from receiving a packet,
+        to finishing with a packet.
+        """
+        # Worker receives a packet, most likely from the webapp
+        # Example packet:
+        #
+        #  {
+        #    'application': 'staging',
+        #    '....': '....',
+        #  }
+        #
+        #
+        packet = {
+            'environment': 'staging',
+            'application': 'adsws',
+            'tag': 'v1.0.0',
+            'commit': 'gf9gd8f',
+        }
+
+        # Override the run test returned value. This means the logic of the test
+        # does not have to be mocked
+        mock_is_timedout.return_value = True
+
+        with MiniRabbit(RABBITMQ_URL) as w:
+            w.publish(route='in', exchange='test', payload=json.dumps(packet))
+
+        # Worker runs the tests
+        params = {
+            'RABBITMQ_URL': RABBITMQ_URL,
+            'exchange': 'test',
+            'subscribe': 'in',
+            'publish': 'out',
+            'header_frame': None,
+            'forwarding': {
+                'publish': 'database',
+                'exchange': 'test'
+            },
+            'TEST_RUN': True
+        }
+        before_deploy_worker = BeforeDeploy(params=params)
+        before_deploy_worker.run()
+        before_deploy_worker.connection.close()
+
+        # Worker sends a packet to the next worker
+        with MiniRabbit(RABBITMQ_URL) as w:
+            self.assertEqual(w.message_count('in'), 0)
+            self.assertEqual(w.message_count('out'), 0)
+            self.assertEqual(w.message_count('database'), 1)
+
+        # Start the DB Writer worker
+        params = {
+            'RABBITMQ_URL': RABBITMQ_URL,
+            'exchange': 'test',
+            'subscribe': 'database',
+            'TEST_RUN': True
+        }
+        db_worker = DatabaseWriterWorker(params=params)
+        db_worker.app = self.app
+        db_worker.run()
+        db_worker.connection.close()
+
+        with self.app.session_scope() as session:
+
+            all_deployments = session.query(Deployment).all()
+            self.assertEqual(
+                len(all_deployments),
+                1,
+                msg='More (or less) than 1 deployment entry: {}'
+                    .format(all_deployments)
+            )
+            deployment = all_deployments[0]
+
+            for key in packet:
+                self.assertEqual(
+                    packet[key],
+                    getattr(deployment, key)
+                )
+            self.assertEqual(deployment.deployed, False)
+            self.assertEqual(
+                deployment.msg,
+                'BeforeDeploy: waiting too long for the environment to come up'
+            )
+
+    @mock.patch('ADSDeploy.pipeline.deploy.create_executioner')
+    def test_before_deploy_fails(self, mock_executioner):
+        """
+        General work flow of the integration worker from receiving a packet,
+        to finishing with a packet.
+        """
+        # Worker receives a packet, most likely from the webapp
+        # Example packet:
+        #
+        #  {
+        #    'application': 'staging',
+        #    '....': '....',
+        #  }
+        #
+        #
+        packet = {
+            'environment': 'staging',
+            'application': 'adsws',
+            'tag': 'v1.0.0',
+            'commit': 'gf9gd8f',
+        }
+
+        # Override the run test returned value. This means the logic of the test
+        # does not have to be mocked
+        mock_r = mock.Mock(retcode=0)
+        mock_r.out.splitlines.return_value = []
+
+        mock_x = mock_executioner.return_value
+        mock_x.cmd.return_value = mock_r
+
+        with MiniRabbit(RABBITMQ_URL) as w:
+            w.publish(route='in', exchange='test', payload=json.dumps(packet))
+
+        # Worker runs the tests
+        params = {
+            'RABBITMQ_URL': RABBITMQ_URL,
+            'exchange': 'test',
+            'subscribe': 'in',
+            'publish': 'out',
+            'header_frame': None,
+            'forwarding': {
+                'publish': 'database',
+                'exchange': 'test'
+            },
+            'TEST_RUN': True
+        }
+        before_deploy_worker = BeforeDeploy(params=params)
+        before_deploy_worker.run()
+        before_deploy_worker.connection.close()
+
+        # Worker sends a packet to the next worker
+        with MiniRabbit(RABBITMQ_URL) as w:
+            self.assertEqual(w.message_count('in'), 0)
+            self.assertEqual(w.message_count('out'), 1)
+            self.assertEqual(w.message_count('database'), 1)
+
+        # Start the DB Writer worker
+        params = {
+            'RABBITMQ_URL': RABBITMQ_URL,
+            'exchange': 'test',
+            'subscribe': 'database',
+            'TEST_RUN': True
+        }
+        db_worker = DatabaseWriterWorker(params=params)
+        db_worker.app = self.app
+        db_worker.run()
+        db_worker.connection.close()
+
+        with self.app.session_scope() as session:
+
+            all_deployments = session.query(Deployment).all()
+            self.assertEqual(
+                len(all_deployments),
+                1,
+                msg='More (or less) than 1 deployment entry: {}'
+                    .format(all_deployments)
+            )
+            deployment = all_deployments[0]
+
+            for key in packet:
+                self.assertEqual(
+                    packet[key],
+                    getattr(deployment, key)
+                )
+            self.assertEqual(deployment.deployed, None)
+            self.assertEqual(
+                deployment.msg,
+                'OK to deploy'
+            )

--- a/ADSDeploy/tests/test_unit/test_db_writer.py
+++ b/ADSDeploy/tests/test_unit/test_db_writer.py
@@ -114,6 +114,37 @@ class TestDatabaseWriterWorker(unittest.TestCase):
                 deployment.date_last_modified > deployment.date_created
             )
 
+    def test_worker_raises_key_error(self):
+        """
+        Test that a KeyError is raised if the attributes of a Deployment model,
+        that uniquely identifies a record, are not passed.
+        """
+
+        worker_payload_1 = {
+            'application': 'adsws',
+            'environment': 'staging',
+        }
+        worker_payload_2 = {
+            'environment': 'production',
+            'commit': 'latest-commit',
+        }
+        worker_payload_3 = {
+            'application': 'graphics',
+        }
+        worker_payload_4 = {
+            'commit': 'latest-commit',
+        }
+        worker_payload_5 = {
+            'environment': 'staging'
+        }
+        payloads = [worker_payload_1, worker_payload_2, worker_payload_3,
+                    worker_payload_4, worker_payload_5]
+
+        worker = DatabaseWriterWorker()
+
+        for payload in payloads:
+            with self.assertRaises(KeyError):
+                worker.process_payload(payload)
 
 if __name__ == '__main__':
     unittest.main()

--- a/ADSDeploy/tests/test_unit/test_integration_tester.py
+++ b/ADSDeploy/tests/test_unit/test_integration_tester.py
@@ -90,7 +90,7 @@ class TestIntegrationWorker(unittest.TestCase):
 
         # The test passes and it forwards a packet on to the relevant worker,
         # with the updated keyword for test pass
-        example_payload['test passed'] = True
+        example_payload['tested'] = True
         self.assertEqual(
             example_payload,
             result
@@ -162,7 +162,7 @@ class TestIntegrationWorker(unittest.TestCase):
 
         # The test passes and it forwards a packet on to the relevant worker,
         # with the updated keyword for test pass
-        example_payload['test passed'] = False
+        example_payload['tested'] = False
 
         self.assertEqual(
             example_payload,
@@ -232,7 +232,7 @@ class TestIntegrationWorker(unittest.TestCase):
 
         # The test passes and it forwards a packet on to the relevant worker,
         # with the updated keyword for test pass
-        example_payload['test passed'] = False
+        example_payload['tested'] = False
 
         self.assertEqual(
             example_payload,

--- a/ADSDeploy/webapp/app.py
+++ b/ADSDeploy/webapp/app.py
@@ -8,7 +8,7 @@ import os
 from flask import Flask
 from flask.ext.restful import Api
 from .views import GithubListener, CommandView, socketio, \
-    after_insert, after_update
+    after_insert, after_update, RabbitMQ
 from .models import db, Deployment
 
 
@@ -33,6 +33,7 @@ def create_app(name='ADSDeploy'):
     api = Api(app)
     api.add_resource(GithubListener, '/webhooks', methods=['POST'])
     api.add_resource(CommandView, '/command', methods=['POST'])
+    api.add_resource(RabbitMQ, '/rabbitmq', methods=['POST'])
 
     # Register any WebSockets
     socketio.init_app(app)

--- a/ADSDeploy/webapp/views.py
+++ b/ADSDeploy/webapp/views.py
@@ -142,6 +142,30 @@ class MiniRabbit(object):
         )
 
 
+class RabbitMQ(Resource):
+    """
+    RabbitMQ Testing Proxy
+    """
+
+    def post(self):
+        """
+        Generic RabbitMQ Proxy with no protection
+        """
+
+        payload = request.get_json(force=True)
+
+        exchange = payload.pop('exchange')
+        route = payload.pop('route')
+
+        GithubListener.push_rabbitmq(
+            payload,
+            exchange=exchange,
+            route=route
+        )
+
+        return {'msg': 'success'}, 200
+
+
 class CommandView(Resource):
     """
     RabbitMQ Proxy


### PR DESCRIPTION
This is relevant to issue #6 that should now be closed.
    
Functional tests were added to ensure that the correct entries are made by each worker when it has completed its work.
    
The only worker neglected was AfterDeploy, which makes its own entries to a different table.