### PR TITLE
Feature issue #13: UI desires

### DIFF
--- a/ADSDeploy/models.py
+++ b/ADSDeploy/models.py
@@ -48,6 +48,11 @@ class Deployment(Base):
     deployed = Column(Boolean, nullable=True)
     tested = Column(Boolean, nullable=True)
     msg = Column(String)
+    status = Column(String)
+
+    @property
+    def version(self):
+        return self.tag if self.tag else self.commit
 
     def toJSON(self):
         """
@@ -59,11 +64,13 @@ class Deployment(Base):
             'environment': self.environment,
             'commit': self.commit,
             'tag': self.tag,
+            'version': self.version,
             'date_created': self.date_created.isoformat(),
             'date_last_modified': self.date_last_modified.isoformat(),
             'deployed': self.deployed,
             'tested': self.tested,
-            'msg': self.msg
+            'msg': self.msg,
+            'status': self.status
         }
 
     def __repr__(self):
@@ -76,11 +83,13 @@ class Deployment(Base):
             '\tenvironment: {}'.format(self.environment),
             '\tcommit: {}'.format(self.commit),
             '\ttag: {}'.format(self.tag),
+            '\tversion: {}'.format(self.version),
             '\tdate_created: {}'.format(self.date_created),
             '\tdate_last_modified: {}'.format(self.date_last_modified),
             '\tdeployed: {}'.format(self.deployed),
             '\ttested: {}'.format(self.tested),
-            '\tmsg: {}'.format(self.msg)
+            '\tmsg: {}'.format(self.msg),
+            '\tstatus: {}'.format(self.status)
         ]
 
         return '<Deployment (\n{}\n)>'.format(', \n'.join(_repr))

--- a/ADSDeploy/tests/test_functional/test_deploy.py
+++ b/ADSDeploy/tests/test_functional/test_deploy.py
@@ -73,6 +73,18 @@ class TestDeployWorker(unittest.TestCase):
             'commit': 'gf9gd8f',
         }
 
+        # Stub the database with some early entries
+        first_deployment = Deployment(
+            environment=packet['environment'],
+            application=packet['application'],
+            tag='v0.0.1',
+            commit='adsfadsf',
+            deployed=True
+        )
+        with self.app.session_scope() as session:
+            session.add(first_deployment)
+            session.commit()
+
         # Override the run test returned value. This means the logic of the test
         # does not have to be mocked. retcode = 1 means it has failed
         mock_r = mock.Mock(retcode=1, command='r-command', err='r-err',
@@ -130,6 +142,10 @@ class TestDeployWorker(unittest.TestCase):
             )
             self.assertIsNone(deployment.deployed)
 
+            deployment = session.query(Deployment)\
+                .filter(Deployment.tag == 'v0.0.1').one()
+            self.assertTrue(deployment.deployed)
+
         db_worker.run()
         with self.app.session_scope() as session:
             deployment = session.query(Deployment)\
@@ -145,6 +161,11 @@ class TestDeployWorker(unittest.TestCase):
                 deployment.msg,
                 'deployment failed; command: r-command, reason: r-err, stdout: r-out'
             )
+
+            deployment = session.query(Deployment)\
+                .filter(Deployment.tag == 'v0.0.1').one()
+
+            self.assertTrue(deployment.deployed)
 
     @mock.patch('ADSDeploy.pipeline.deploy.create_executioner')
     def test_deploy_succeeds(self, mock_executioner):
@@ -167,6 +188,18 @@ class TestDeployWorker(unittest.TestCase):
             'tag': 'v1.0.0',
             'commit': 'gf9gd8f',
         }
+
+        # Stub the database with some early entries
+        first_deployment = Deployment(
+            environment=packet['environment'],
+            application=packet['application'],
+            tag='v0.0.1',
+            commit='adsfadsf',
+            deployed=True
+        )
+        with self.app.session_scope() as session:
+            session.add(first_deployment)
+            session.commit()
 
         # Override the run test returned value. This means the logic of the test
         # does not have to be mocked. retcode = 1 means it has failed
@@ -224,6 +257,10 @@ class TestDeployWorker(unittest.TestCase):
             )
             self.assertIsNone(deployment.deployed)
 
+            deployment = session.query(Deployment)\
+                .filter(Deployment.tag == 'v0.0.1').one()
+            self.assertTrue(deployment.deployed)
+
         db_worker.run()
         with self.app.session_scope() as session:
             deployment = session.query(Deployment)\
@@ -239,3 +276,7 @@ class TestDeployWorker(unittest.TestCase):
                 deployment.msg,
                 'deployed'
             )
+
+            deployment = session.query(Deployment)\
+                .filter(Deployment.tag == 'v0.0.1').one()
+            self.assertFalse(deployment.deployed)

--- a/ADSDeploy/tests/test_unit/test_webapp.py
+++ b/ADSDeploy/tests/test_unit/test_webapp.py
@@ -133,7 +133,7 @@ class TestStaticMethodUtilities(TestCase):
         r.data = github_payload
         c = GithubListener.parse_github_payload(r)
         self.assertEqual(
-            c['repository'],
+            c['application'],
             'adsws'
         )
         self.assertEqual(
@@ -141,7 +141,7 @@ class TestStaticMethodUtilities(TestCase):
             None
         )
 
-        for key in ['repository', 'environment', 'commit', 'author', 'tag']:
+        for key in ['application', 'environment', 'commit', 'author', 'tag']:
             self.assertIn(
                 key,
                 c,
@@ -160,7 +160,7 @@ class TestStaticMethodUtilities(TestCase):
 
         c = GithubListener.parse_github_payload(r)
         self.assertEqual(
-            c['repository'],
+            c['application'],
             'adsws'
         )
         self.assertEqual(
@@ -168,7 +168,7 @@ class TestStaticMethodUtilities(TestCase):
             'v1.0.0'
         )
 
-        for key in ['repository', 'environment', 'commit', 'author', 'tag']:
+        for key in ['application', 'environment', 'commit', 'author', 'tag']:
             self.assertIn(
                 key,
                 c,
@@ -188,7 +188,7 @@ class TestStaticMethodUtilities(TestCase):
         instance_rabbit.publish.side_effect = None
 
         payload = OrderedDict([
-            ('repository', 'important-service'),
+            ('application', 'important-service'),
             ('commit', 'd8fgdfgdf'),
             ('environment', 'staging'),
             ('author', 'author'),

--- a/ADSDeploy/utils.py
+++ b/ADSDeploy/utils.py
@@ -39,7 +39,7 @@ def get_date(timestr=None):
     Always parses the time to be in the UTC time zone; or returns
     the current date (with UTC timezone specified)
     
-    :param: timestr
+    :param timestr: time string
     :type: str or None
     
     :return: datetime object with tzinfo=tzutc()
@@ -86,6 +86,7 @@ def load_config():
     
     return conf
 
+
 def load_module(filename):
     """
     Loads module, first from config.py then from local_config.py
@@ -104,6 +105,7 @@ def load_module(filename):
     res = {}
     from_object(d, res)
     return res
+
 
 def setup_logging(file_, name_, level='DEBUG'):
     """

--- a/ADSDeploy/webapp/app.py
+++ b/ADSDeploy/webapp/app.py
@@ -8,7 +8,7 @@ import os
 from flask import Flask
 from flask.ext.restful import Api
 from .views import GithubListener, CommandView, socketio, \
-    after_insert, after_update, RabbitMQ
+    after_insert, after_update, RabbitMQ, StatusView
 from .models import db, Deployment
 
 
@@ -32,8 +32,9 @@ def create_app(name='ADSDeploy'):
     # Register extensions
     api = Api(app)
     api.add_resource(GithubListener, '/webhooks', methods=['POST'])
-    api.add_resource(CommandView, '/command', methods=['POST'])
+    api.add_resource(CommandView, '/command', methods=['GET'])
     api.add_resource(RabbitMQ, '/rabbitmq', methods=['POST'])
+    api.add_resource(StatusView, '/status', methods=['GET'])
 
     # Register any WebSockets
     socketio.init_app(app)


### PR DESCRIPTION
Some desires required for the UI:

  - /status end point returning only active deployments
  - DB Writer worker tests, and awareness of making deployments inactive
  - on connect returns 'on connect', on disconnected 'disconnect'
  - /command is a GET end point that accepts parameters, currently is action agnostic