### PR TITLE
Feature Issue#17: queue forwarding

### DIFF
--- a/ADSDeploy/config.py
+++ b/ADSDeploy/config.py
@@ -9,7 +9,7 @@ SQLALCHEMY_ECHO = False
 # Configuration of the pipeline; if you start 'vagrant up rabbitmq' 
 # container, the port is localhost:6672 - but for production, you 
 # want to point to the ADSImport pipeline 
-RABBITMQ_URL = 'amqp://guest:guest@127.0.0.1:6672/?' \
+RABBITMQ_URL = 'amqp://guest:guest@127.0.0.1:6672/adsdeploy?' \
                'socket_timeout=10&backpressure_detection=t'
                
 
@@ -31,10 +31,7 @@ WORKERS = {
         'concurrency': 1,
         'subscribe': 'ads.deploy.before_deploy',
         'publish': 'ads.deploy.deploy',
-        'forwarding': {
-            'exchange': EXCHANGE,
-            'publish': 'ads.deploy.status'
-        },
+        'status': 'ads.deploy.status',
         'error': 'ads.deploy.error',
         'durable': True
     },
@@ -42,10 +39,7 @@ WORKERS = {
         'concurrency': 1,
         'subscribe': 'ads.deploy.deploy',
         'publish': 'ads.deploy.test',
-        'forwarding': {
-            'exchange': EXCHANGE,
-            'publish': 'ads.deploy.status'
-        },
+        'status': 'ads.deploy.status',
         'error': 'ads.deploy.error',
         'durable': True
     },
@@ -53,10 +47,7 @@ WORKERS = {
         'concurrency': 1,
         'subscribe': 'ads.deploy.test',
         'publish': 'ads.deploy.after_deploy',
-        'forwarding': {
-            'exchange': EXCHANGE,
-            'publish': 'ads.deploy.status'
-        },
+        'status': 'ads.deploy.status',
         'error': 'ads.deploy.error',
         'durable': True
     },
@@ -69,6 +60,7 @@ WORKERS = {
     },
     'errors.ErrorHandler': {
         'subscribe': 'ads.deploy.error',
+        'status': 'ads.deploy.status',
         'publish': None,
         'durable': False
     }

--- a/ADSDeploy/pipeline/integration_tester.py
+++ b/ADSDeploy/pipeline/integration_tester.py
@@ -131,4 +131,4 @@ class IntegrationTestWorker(RabbitMQWorker):
         self.logger.info('Publishing to queue: {}'.format(self.publish_topic))
 
         self.publish(result)
-        self.forward(result)
+        self.publish(result, topic=self.params['status'])

--- a/ADSDeploy/pipeline/workers.py
+++ b/ADSDeploy/pipeline/workers.py
@@ -4,4 +4,4 @@ Place holder for all workers
 """
 from .integration_tester import IntegrationTestWorker
 from .db_writer import DatabaseWriterWorker
-from .deploy import BeforeDeploy, Deploy
+from .deploy import BeforeDeploy, Deploy, Restart

--- a/ADSDeploy/tests/test_functional/test_integration_tester.py
+++ b/ADSDeploy/tests/test_functional/test_integration_tester.py
@@ -15,7 +15,7 @@ from ADSDeploy.pipeline.workers import IntegrationTestWorker, \
 from ADSDeploy.webapp.views import MiniRabbit
 from ADSDeploy.models import Base, Deployment
 
-RABBITMQ_URL = 'amqp://guest:guest@172.17.0.1:6672/?' \
+RABBITMQ_URL = 'amqp://guest:guest@172.17.0.1:6672/adsdeploy_test?' \
                'socket_timeout=10&backpressure_detection=t'
 
 
@@ -91,6 +91,7 @@ class TestIntegrationTestWorker(unittest.TestCase):
             'exchange': 'test',
             'subscribe': 'in',
             'publish': 'out',
+            'status': 'database',
             'TEST_RUN': True
         }
         test_worker = IntegrationTestWorker(params=params)
@@ -137,10 +138,7 @@ class TestIntegrationTestWorker(unittest.TestCase):
             'exchange': 'test',
             'subscribe': 'in',
             'publish': 'out',
-            'forwarding': {
-                'publish': 'database',
-                'exchange': 'test'
-            },
+            'status': 'database',
             'TEST_RUN': True
         }
 

--- a/ADSDeploy/tests/test_functional/test_webapp.py
+++ b/ADSDeploy/tests/test_functional/test_webapp.py
@@ -7,7 +7,6 @@ It then shuts down all of the workers.
 """
 
 
-import json
 import unittest
 import requests
 
@@ -18,6 +17,10 @@ from ADSDeploy.config import RABBITMQ_URL, WEBAPP_URL
 class TestWebApp(unittest.TestCase):
     """
     Test the interactions of the webapp with other services, such as RabbitMQ
+
+    Note: this only works when assuming that the exchange set by RabbitMQ in
+    the configuration file has been used. Specifically, EXCHANGE='test', and
+    ROUTE='test', used to define the queue for the webapp.
     """
 
     def setUp(self):
@@ -35,13 +38,14 @@ class TestWebApp(unittest.TestCase):
 
         url = 'http://{}/command'.format(WEBAPP_URL)
 
-        payload = {
+        params = {
             'application': 'staging',
             'environment': 'adsws',
-            'commit': 's23rfef3',
+            'version': 's23rfef3',
+            'action': 'deploy'
         }
 
-        r = requests.post(url, data=json.dumps(payload))
+        r = requests.get(url, params=params)
 
         self.assertEqual(r.status_code, 200)
 
@@ -59,8 +63,8 @@ class TestWebApp(unittest.TestCase):
 
         self.assertEqual(
             packet,
-            payload,
-            msg='Packet received {} != payload sent {}'.format(packet, payload)
+            params,
+            msg='Packet received {} != payload sent {}'.format(packet, params)
         )
 
 

--- a/ADSDeploy/tests/test_unit/test_deploy.py
+++ b/ADSDeploy/tests/test_unit/test_deploy.py
@@ -48,9 +48,12 @@ class TestWorkers(test_base.TestUnit):
         # BeforeDeploy requires EB_DEPLOY path to exist
         exists.return_value = True
 
-        worker = BeforeDeploy()
+        worker = BeforeDeploy(params={'status': 'ads.deploy.status'})
         worker.process_payload({'application': 'sandbox', 'environment': 'adsws'})
-        worker.publish.assert_called_with({'environment': 'adsws', 'application': 'sandbox', 'msg': 'OK to deploy'})
+        worker.publish.assert_has_calls([
+            mock.call({'environment': 'adsws', 'application': 'sandbox', 'msg': 'OK to deploy'},topic='ads.deploy.deploy'),
+            mock.call({'environment': 'adsws', 'application': 'sandbox', 'msg': 'OK to deploy'},topic='ads.deploy.status')
+        ])
 
     def test_deploy_after_deploy(self):
         """Test after deploy"""

--- a/ADSDeploy/tests/test_unit/test_webservices.py
+++ b/ADSDeploy/tests/test_unit/test_webservices.py
@@ -107,10 +107,12 @@ class TestEndpoints(TestCase):
         self.assertStatus(r, 200)
         self.assertEqual(r.json['msg'], 'success')
 
-        mocked_gh.push_rabbitmq.assert_has_calls(
-            [mock.call(params, exchange='unit-test-exchange',
-                       route='unit-test-route')]
-        )
+        params['commit'] = params['version']
+        mocked_gh.push_rabbitmq.assert_has_calls([mock.call(
+            params,
+            exchange='unit-test-exchange',
+            route='unit-test-route'
+        )])
 
     @mock.patch('ADSDeploy.webapp.views.GithubListener')
     def test_commandview_missing_payload(self, mocked_gh):

--- a/ADSDeploy/webapp/views.py
+++ b/ADSDeploy/webapp/views.py
@@ -265,6 +265,9 @@ class CommandView(Resource):
                                          .format(key, args))
                 abort(400, 'Missing keyword: {}'.format(key))
 
+        # Currently, version is a synonym to commit
+        args['commit'] = args['version']
+
         GithubListener.push_rabbitmq(
             args,
             exchange=current_app.config.get('EXCHANGE'),


### PR DESCRIPTION
References adsabs/bumblebee/issues/793

Should close local issue #17.

* Replaced the inefficient call of .forward() with .publish(), and used a configuration parameter to define the status queue, much like the publish_to_error_queue works. Although it is a tiny bit more boiler plate code, given (nearly) all workers publish to the status queue, it is neater to see it in the config.

* Updated the tests for changes made.

* Added functional tests for the Restart worker, that are passing.

* Fixed the broken tests.

* Currently, version == commit. This should be changed in the future.